### PR TITLE
fix #15

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -22,15 +22,8 @@ if [ ! -f "/ircd/ircd.yaml" ]; then
     mv /tmp/ircd2.yaml /ircd/ircd.yaml
 fi
 
-# make db
-if [ ! -f "/ircd/ircd.db" ]; then
-    /ircd-bin/oragono initdb
-fi
-
-# make self-signed certs
-if [ ! -f "/ircd/tls.key" ]; then
-    /ircd-bin/oragono mkcerts
-fi
+# make self-signed certs if they don't already exist
+/ircd-bin/oragono mkcerts
 
 # run!
 exec /ircd-bin/oragono run


### PR DESCRIPTION
`oragono initdb` is no longer required (since https://github.com/oragono/oragono/issues/322), and `oragono mkcerts` no longer overwrites so it can be invoked unconditionally (the script doesn't use `-e` so it's fine for the invocation to fail).

I don't have a working docker install, maybe @povoq could test this?