### PR TITLE
Stable updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,6 @@ FROM golang:rc-alpine AS build-env
 
 RUN apk add --no-cache git make curl
 
-# install goreleaser
-RUN mkdir -p /go/src/github.com/goreleaser
-WORKDIR /go/src/github.com/goreleaser
-
-RUN git clone https://github.com/goreleaser/goreleaser.git
-WORKDIR /go/src/github.com/goreleaser/goreleaser
-RUN make setup build
-RUN cp ./goreleaser /usr/bin
-
 # get oragono
 RUN mkdir -p /go/src/github.com/oragono
 WORKDIR /go/src/github.com/oragono
@@ -20,7 +11,7 @@ RUN git clone --recurse-submodules https://github.com/oragono/oragono.git
 WORKDIR /go/src/github.com/oragono/oragono
 
 # compile
-RUN make build
+RUN make
 
 
 
@@ -41,7 +32,7 @@ EXPOSE 6667/tcp 6697/tcp
 
 # oragono itself
 RUN mkdir -p /ircd-bin
-COPY --from=build-env /go/src/github.com/oragono/oragono/dist/linux_amd64/oragono /ircd-bin
+COPY --from=build-env /go/bin/oragono /ircd-bin
 COPY --from=build-env /go/src/github.com/oragono/oragono/languages /ircd-bin/languages/
 COPY --from=build-env /go/src/github.com/oragono/oragono/oragono.yaml /ircd-bin/oragono.yaml
 COPY run.sh /ircd-bin/run.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ related materials.
 
 The following tags are available:
 
- * `dev` - latest development version; published periodically (may be unstable)
+ * `latest` - latest stable release
+ * `dev` - latest development version (may be unstable)
 
 ## Quick start
 
@@ -17,10 +18,25 @@ certificates. To get a working ircd, all you need to do is run the image and
 expose the ports:
 
 ```shell
-docker run -d -P oragono/oragono:tag
+docker run --name oragono -d -P oragono/oragono:tag
 ```
 
 This will start Oragono and listen on ports 6667 (plain text) and 6697 (TLS).
+The first time Oragono runs it will create a config file with a randomised
+oper password. This is output to stdout, and you can view it with the docker
+logs command:
+
+```shell
+# Assuming your container is named `oragono`; use `docker container ls` to
+# find the name if you're not sure.
+docker logs oragono
+```
+
+You should see a line similar to:
+
+```
+Oper username:password is dan:cnn2tm9TP3GeI4vLaEMS
+```
 
 ## Persisting data
 
@@ -49,8 +65,7 @@ exist, the default config will be written out. You can copy the config from
 the container, edit it, and then copy it back:
 
 ```shell
-# These commands assume the container is named `oragono`
-# If you didn't name it, use `docker container ls` to find the name
+# Assuming that your container is named `oragono`, as above.
 docker cp oragono:/ircd/ircd.yaml .
 vim ircd.yaml # edit the config to your liking
 docker cp ircd.yaml oragono:/ircd/ircd.yaml

--- a/README.md
+++ b/README.md
@@ -1,3 +1,83 @@
 # Oragono Docker
 
-This repo holds Oragono's Dockerfiles and such.
+This repo holds [Oragono](https://github.com/oragono/oragono)'s Dockerfiles and
+related materials.
+
+## Tags
+
+The following tags are available:
+
+ * `dev` - latest development version; published periodically (may be unstable)
+
+## Quick start
+
+The Oragono docker image is designed to work out of the box - it comes with a
+usable default config and will automatically generate self-signed TLS
+certificates. To get a working ircd, all you need to do is run the image and
+expose the ports:
+
+```shell
+docker run -d -P oragono/oragono:tag
+```
+
+This will start Oragono and listen on ports 6667 (plain text) and 6697 (TLS).
+
+## Persisting data
+
+Oragono has a persistent data store, used to keep account details, channel
+registrations, and so on. To persist this data across restarts, you can mount
+a volume at /ircd.
+
+For example, to create a new docker volume and then mount it:
+
+```shell
+docker volume create oragono-data
+docker run -d -v oragono-data:/ircd -P oragono/oragono:tag
+```
+
+Or to mount a folder from your host machine:
+
+```shell
+mkdir oragono-data
+docker run -d -v $(PWD)/oragono-data:/ircd -P oragono/oragono:tag
+```
+
+## Customising the config
+
+Oragono's config file is stored at /ircd/ircd.yaml. If the file does not
+exist, the default config will be written out. You can copy the config from
+the container, edit it, and then copy it back:
+
+```shell
+# These commands assume the container is named `oragono`
+# If you didn't name it, use `docker container ls` to find the name
+docker cp oragono:/ircd/ircd.yaml .
+vim ircd.yaml # edit the config to your liking
+docker cp ircd.yaml oragono:/ircd/ircd.yaml
+```
+
+You can use the `/rehash` command to make Oragono reload its config, or
+send it the HUP signal:
+
+```shell
+docker kill -HUP oragono
+```
+
+## Using custom TLS certificates
+
+TLS certs will by default be read from /ircd/tls.crt, with a private key
+in /ircd/tls.key. You can customise this path in the ircd.yaml file if
+you wish to mount the certificates from another volume. For information
+on using Let's Encrypt certificates, see
+[this manual entry](https://github.com/oragono/oragono/blob/master/docs/MANUAL.md#how-do-i-use-lets-encrypt-certificates).
+
+## Using docker-compose
+
+This repository contains a sample docker-compose file which can be used
+to start an Oragono instance with ports exposed and data persisted in
+a docker volume. Simply download the file and then bring it up:
+
+```shell
+curl -O https://raw.githubusercontent.com/oragono/oragono-docker/master/docker-compose.yml
+docker-compose up -d
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,12 @@ version: "3.2"
 
 services:
   oragono:
-    image: oragono/oragono
+    image: oragono/oragono:dev
     ports:
       - "6667:6667/tcp"
       - "6697:6697/tcp"
+    volumes:
+      - data:/ircd
     deploy:
       placement:
         constraints:
@@ -13,3 +15,6 @@ services:
       restart_policy:
         condition: on-failure
       replicas: 1
+
+volumes:
+  data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 
 services:
   oragono:
-    image: oragono/oragono
+    image: oragono/oragono:latest
     ports:
       - "6667:6667/tcp"
       - "6697:6697/tcp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 
 services:
   oragono:
-    image: oragono/oragono:latest
+    image: oragono/oragono
     ports:
       - "6667:6667/tcp"
       - "6697:6697/tcp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 
 services:
   oragono:
-    image: oragono/oragono:dev
+    image: oragono/oragono:latest
     ports:
       - "6667:6667/tcp"
       - "6697:6697/tcp"

--- a/run.sh
+++ b/run.sh
@@ -22,15 +22,8 @@ if [ ! -f "/ircd/ircd.yaml" ]; then
     mv /tmp/ircd2.yaml /ircd/ircd.yaml
 fi
 
-# make db
-if [ ! -f "/ircd/ircd.db" ]; then
-    /ircd-bin/oragono initdb
-fi
-
-# make self-signed certs
-if [ ! -f "/ircd/tls.key" ]; then
-    /ircd-bin/oragono mkcerts
-fi
+# make self-signed certs if they don't already exist
+/ircd-bin/oragono mkcerts
 
 # run!
 exec /ircd-bin/oragono run


### PR DESCRIPTION
@csmith wondering if you could test this?

Basically, I just merged master into stable, then fixed the definition of `image`. The resulting diff from master to stable is:

````diff
diff --git a/Dockerfile b/Dockerfile
index e3aaef3..8057aa9 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache git make curl
 RUN mkdir -p /go/src/github.com/oragono
 WORKDIR /go/src/github.com/oragono
 
-RUN git clone --recurse-submodules https://github.com/oragono/oragono.git
+RUN git clone --recurse-submodules -b stable https://github.com/oragono/oragono.git
 WORKDIR /go/src/github.com/oragono/oragono
 
 # compile
diff --git a/docker-compose.yml b/docker-compose.yml
index 512e6c0..9633436 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.2"
 
 services:
   oragono:
-    image: oragono/oragono:latest
+    image: oragono/oragono
     ports:
       - "6667:6667/tcp"
       - "6697:6697/tcp"

````